### PR TITLE
Build was failing after clean as nekoml.std depends

### DIFF
--- a/src/tools/install.neko
+++ b/src/tools/install.neko
@@ -404,6 +404,11 @@ exec(nekovm+" nekoml -nostd -p tools Tools.nml");
 exec(nekovm+" nekoc -link tools/nekotools.n Tools");
 copy("tools/nekotools.n",base);
 
+// build zlib, as nekoml.std depends on it it
+chdir("../libs");
+compile_lib("zlib", libs.zlib);
+chdir("../src");
+
 // build nekoml.std
 var cmd = nekovm+" nekoml -nostd neko/Main.nml nekoml/Main.nml";
 var core_files = readdir("core");


### PR DESCRIPTION
Hi Nicolas,

Not sure if this is the right solution, but build was failing after clean as zlib.ndll is needed to build nekoml.std

Now install.neko builds zlib.ndll, nekoml.std, all libs, then nekoml.std (again).

Best,
David
