### PR TITLE
Fix a bug with std@resolve

### DIFF
--- a/libs/std/socket.c
+++ b/libs/std/socket.c
@@ -341,10 +341,23 @@ static value host_resolve( value host ) {
 #	if defined(NEKO_WINDOWS) || defined(NEKO_MAC)
 		h = gethostbyname(val_string(host));
 #	else
-		struct hostent hbase;
-		char buf[1024];
-		int errcode;
-		gethostbyname_r(val_string(host),&hbase,buf,1024,&h,&errcode);
+		int i;
+		struct addrinfo *ai;
+		int errcode = getaddrinfo(val_string(host), NULL, NULL, &ai);
+
+		if (errcode != 0)
+			neko_error();
+
+		for (i = 0; ai; ai = ai->ai_next, i++)
+		{
+			const struct in_addr *addr4 = &((const struct sockaddr_in*)ai->ai_addr)->sin_addr;
+
+			if (ai->ai_family == AF_INET)
+				return alloc_int32(addr4->s_addr);
+		}
+
+		neko_error();
+
 #	endif
 		if( h == NULL )
 			neko_error();


### PR DESCRIPTION
Std@resolve doesn't work on some linux platforms (can't figure out which) (it's throwing an exception with neko_error())
It's caused by the use of the old gethostbyname method.

I've replaced gethostbyname with getaddrinfo, and tested it. It works successfully.

I'm not a C coder, so please tell me if there's something wrong with the diff, I'll fix it.