### PR TITLE
Memleak

### DIFF
--- a/libs/mod_neko/mod_neko.c
+++ b/libs/mod_neko/mod_neko.c
@@ -333,9 +333,9 @@ static void mod_neko_do_init() {
 	s = strdup("MOD_NEKO=1");
 #	endif
 	if (s != NULL) {
-	    if (0 != putenv(s)) {
-		free(s);
-	    }
+	        if (0 != putenv(s)) {
+		        free(s);
+		}
 	}
 	neko_global_init();
 	cache_root = alloc_local();


### PR DESCRIPTION
if putenv() fails then memory allocated by strdup() remains unfreed. 
if strdup() fails then putenv() gets NULL as an argument and its behaviour is not defined in this case.
This patch fixes both cases.
Though if any of these functions fails, the module is not configured properly. This situation may need to be addressed.
