### PR TITLE
when building libs, respect -silent for lib dependencies

### DIFF
--- a/src/tools/install.neko
+++ b/src/tools/install.neko
@@ -364,6 +364,10 @@ compile_lib = function(name,data) {
 		linklib = "";
 	else {
 		while( (dir = find_file(linklib,libraries)) == null ) {
+			if( silent ) {
+				$print("The file "+linklib+" not found, skipping "+data.incname+" library compilation\n");
+				return;
+			}
 			$print("The file "+linklib+" provided when installing "+data.incname+" was not found\n");
 			$print("Please enter a valid include path to look for it\n");
 			$print("Or 's' to skip this library\n");


### PR DESCRIPTION
Same as [when *.h is missing](https://github.com/HaxeFoundation/neko/blob/master/src/tools/install.neko#L332), it should skip the lib compilation when `-silent` is given.
