### PR TITLE
Fix overlapping memcpy

### DIFF
--- a/libs/mod_neko/cgi.c
+++ b/libs/mod_neko/cgi.c
@@ -342,7 +342,7 @@ static value parse_multipart_data( value onpart, value ondata ) {
 		while( true ) {
 			const char *boundary;
 			// recall buffer
-			memcpy(val_string(buf),val_string(buf)+pos,len - pos);
+			memmove(val_string(buf),val_string(buf)+pos,len - pos);
 			len -= pos;
 			pos = 0;
 			fill_buffer(c,buf,&len);
@@ -362,7 +362,7 @@ static value parse_multipart_data( value onpart, value ondata ) {
 				pos = (int)(boundary - val_string(buf));
 				val_call3(ondata,buf,alloc_int(0),alloc_int(pos-2));
 				// recall
-				memcpy(val_string(buf),val_string(buf)+pos,len - pos);
+				memmove(val_string(buf),val_string(buf)+pos,len - pos);
 				len -= pos;
 				break;
 			}

--- a/libs/mod_tora/protocol.c
+++ b/libs/mod_tora/protocol.c
@@ -355,7 +355,7 @@ static bool send_multipart_data( proto *p, char *buf, int bufsize ) {
 		while( true ) {
 			const char *boundary;
 			// recall buffer
-			memcpy(buf,buf+pos,len - pos);
+			memmove(buf,buf+pos,len - pos);
 			len -= pos;
 			pos = 0;
 			len = fill_buffer(p,buf,bufsize,len);
@@ -377,7 +377,7 @@ static bool send_multipart_data( proto *p, char *buf, int bufsize ) {
 				pos = (int)(boundary - buf);
 				proto_send_size(p,CODE_PART_DATA,buf,pos - 2);
 				// recall
-				memcpy(buf,buf+pos,len - pos);
+				memmove(buf,buf+pos,len - pos);
 				len -= pos;
 				break;
 			}


### PR DESCRIPTION
memcpy is not safe with overlapping areas and acts randomly on recent 64b linux.
