### PR TITLE
Fix compiler warnings ("undeclared casts", depreceated GC calls); use mem* functions instead of while loops for improved performance

### DIFF
--- a/vm/alloc.c
+++ b/vm/alloc.c
@@ -91,7 +91,7 @@ field id_get, id_set;
 field id_add, id_radd, id_sub, id_rsub, id_mult, id_rmult, id_div, id_rdiv, id_mod, id_rmod;
 EXTERN field neko_id_module;
 
-#if defined (GC_LOG) && defined(NEKO_POSIX) 
+#if defined (GC_LOG) && defined(NEKO_POSIX)
 static void handle_signal( int signal ) {
 	// reset to default handler
 	struct sigaction act;
@@ -121,19 +121,19 @@ void neko_gc_init() {
 #	ifndef NEKO_WINDOWS
 	// we can't set this on windows with old GC since
 	// it's already initialized through its own DllMain
-	GC_all_interior_pointers = 0;
+	GC_set_all_interior_pointers(0);
 #	endif
 #if (GC_VERSION_MAJOR >= 7) && defined(NEKO_WINDOWS)
-	GC_all_interior_pointers = 0;
+	GC_set_all_interior_pointers(0);
 #	ifndef NEKO_STANDALONE
 	GC_use_DllMain(); // needed to auto-detect threads created by Apache
 #	endif
 #endif
-	GC_java_finalization = 1;
+	GC_set_java_finalization(1);
 	GC_init();
-	GC_no_dls = 1;
+	GC_set_no_dls(1);
 #ifdef LOW_MEM
-	GC_dont_expand = 1;
+	GC_set_dont_expand(1);
 #endif
 	GC_clear_roots();
 #if defined(GC_LOG) && defined(NEKO_POSIX)
@@ -222,7 +222,7 @@ EXTERN value alloc_abstract( vkind k, void *data ) {
 
 EXTERN value alloc_function( void *c_prim, unsigned int nargs, const char *name ) {
 	vfunction *v;
-	if( c_prim == NULL || (nargs < 0 && nargs != VAR_ARGS) )
+	if( c_prim == NULL || ((int)nargs < 0 && nargs != VAR_ARGS) )
 		failure("alloc_function");
 	v = (vfunction*)gc_alloc(sizeof(vfunction));
 	v->t = VAL_PRIMITIVE;

--- a/vm/interp.c
+++ b/vm/interp.c
@@ -192,7 +192,7 @@ EXTERN void neko_vm_set_custom( neko_vm *vm, vkind k, void *v ) {
 	c->tag = k;
 	c->custom = v;
 	c->next = vm->clist;
-	vm->clist = c;	
+	vm->clist = c;
 }
 
 typedef struct {
@@ -282,7 +282,7 @@ static int_val jit_run( neko_vm *vm, vfunction *acc ) {
 #ifdef NEKO_THREADED
 #	define Instr(x)	Label##x:
 #	ifdef NEKO_DIRECT_THREADED
-#		define Next		goto **pc++;
+#		define Next		goto *((const void *)*pc++);
 #	else
 #		define Next		goto **(instructions + *pc++);
 #	endif

--- a/vm/module.c
+++ b/vm/module.c
@@ -352,7 +352,7 @@ neko_module *neko_read_module( reader r, readp p, value loader ) {
 	READ_LONG(m->nglobals);
 	READ_LONG(m->nfields);
 	READ_LONG(m->codesize);
-	if( m->nglobals < 0 || m->nglobals > 0xFFFF || m->nfields < 0 || m->nfields > 0xFFFF || m->codesize < 0 || m->codesize > 0xFFFFFF )
+	if( (int)m->nglobals < 0 || m->nglobals > 0xFFFF || (int)m->nfields < 0 || m->nfields > 0xFFFF || (int)m->codesize < 0 || m->codesize > 0xFFFFFF )
 		ERROR();
 	tmp = (char*)malloc(sizeof(char)*(((m->codesize+1)>MAXSIZE)?(m->codesize+1):MAXSIZE));
 	m->jit = NULL;

--- a/vm/objtable.c
+++ b/vm/objtable.c
@@ -39,8 +39,8 @@ int otable_remove( objtable *t, field id ) {
 			max = mid;
 		else {
 			t->count--;
-            memmove(&c[mid], &c[mid + 1], (t->count - mid) * sizeof(objcell));
-            c[t->count].v = val_null;
+			memmove(&c[mid], &c[mid + 1], (t->count - mid) * sizeof(objcell));
+			c[t->count].v = val_null;
 			return 1;
 		}
 	}
@@ -81,12 +81,12 @@ void otable_replace( objtable *t, field id, value data ) {
 		}
 	}
 	mid = (min + max) >> 1;
-    const size_t objcell_size = sizeof(objcell);
+	const size_t objcell_size = sizeof(objcell);
 	c = (objcell*)alloc(objcell_size * (t->count + 1));
-    memcpy(c, t->cells, mid * objcell_size);
-    c[mid].id = id;
-    c[mid].v = data;
-    memcpy(&c[mid + 1], &t->cells[mid], (t->count - mid) * objcell_size);
+	memcpy(c, t->cells, mid * objcell_size);
+	c[mid].id = id;
+	c[mid].v = data;
+	memcpy(&c[mid + 1], &t->cells[mid], (t->count - mid) * objcell_size);
 	t->cells = c;
 	t->count++;
 }

--- a/vm/objtable.c
+++ b/vm/objtable.c
@@ -101,14 +101,15 @@ void otable_replace( objtable *t, field id, value data ) {
 }
 
 void otable_copy( objtable *t, objtable *target ) {
-	target->count = t->count;
-	target->cells = (objcell*)alloc(sizeof(objcell)*t->count);
-	memcpy(target->cells,t->cells,sizeof(objcell)*t->count);
+    target->count = t->count;
+    const size_t size = sizeof(objcell) * t->count;
+    target->cells = (objcell*)alloc(size);
+    memcpy(target->cells,t->cells,size);
 }
 
 void otable_iter(objtable *t, void f( value data, field id, void *), void *p ) {
 	int i;
-	int n = t->count;
+	const int n = (const int)t->count;
 	objcell *c = t->cells;
 	for(i=0;i<n;i++)
 		f(c[i].v,c[i].id,p);

--- a/vm/objtable.c
+++ b/vm/objtable.c
@@ -39,11 +39,8 @@ int otable_remove( objtable *t, field id ) {
 			max = mid;
 		else {
 			t->count--;
-			while( mid < t->count ) {
-				c[mid] = c[mid+1];
-				mid++;
-			}
-			c[mid].v = val_null;
+            memmove(&c[mid], &c[mid + 1], (void*)&c[t->count] - (void*)&c[mid]);
+            c[t->count].v = val_null;
 			return 1;
 		}
 	}
@@ -84,18 +81,11 @@ void otable_replace( objtable *t, field id, value data ) {
 		}
 	}
 	mid = (min + max) >> 1;
-	c = (objcell*)alloc(sizeof(objcell)*(t->count + 1));
-	min = 0;
-	while( min < mid ) {
-		c[min] = t->cells[min];
-		min++;
-	}
-	c[mid].id = id;
-	c[mid].v = data;
-	while( min < t->count ) {
-		c[min+1] = t->cells[min];
-		min++;
-	}
+	c = (objcell*)alloc(sizeof(objcell) * (t->count + 1));
+    memcpy(c, t->cells, (void*)&c[mid] - (void*)c);
+    c[mid].id = id;
+    c[mid].v = data;
+    memcpy(&c[mid + 1], &t->cells[mid], (void*)&c[t->count] - (void*)&c[mid]);
 	t->cells = c;
 	t->count++;
 }

--- a/vm/objtable.c
+++ b/vm/objtable.c
@@ -92,10 +92,10 @@ void otable_replace( objtable *t, field id, value data ) {
 }
 
 void otable_copy( objtable *t, objtable *target ) {
-    target->count = t->count;
-    const size_t size = sizeof(objcell) * t->count;
-    target->cells = (objcell*)alloc(size);
-    memcpy(target->cells,t->cells,size);
+	target->count = t->count;
+	const size_t size = sizeof(objcell) * t->count;
+	target->cells = (objcell*)alloc(size);
+	memcpy(target->cells,t->cells,size);
 }
 
 void otable_iter(objtable *t, void f( value data, field id, void *), void *p ) {

--- a/vm/objtable.c
+++ b/vm/objtable.c
@@ -39,7 +39,7 @@ int otable_remove( objtable *t, field id ) {
 			max = mid;
 		else {
 			t->count--;
-            memmove(&c[mid], &c[mid + 1], (void*)&c[t->count] - (void*)&c[mid]);
+            memmove(&c[mid], &c[mid + 1], (t->count - mid) * sizeof(objcell));
             c[t->count].v = val_null;
 			return 1;
 		}
@@ -81,11 +81,12 @@ void otable_replace( objtable *t, field id, value data ) {
 		}
 	}
 	mid = (min + max) >> 1;
-	c = (objcell*)alloc(sizeof(objcell) * (t->count + 1));
-    memcpy(c, t->cells, (void*)&c[mid] - (void*)c);
+    const size_t objcell_size = sizeof(objcell);
+	c = (objcell*)alloc(objcell_size * (t->count + 1));
+    memcpy(c, t->cells, mid * objcell_size);
     c[mid].id = id;
     c[mid].v = data;
-    memcpy(&c[mid + 1], &t->cells[mid], (void*)&c[t->count] - (void*)&c[mid]);
+    memcpy(&c[mid + 1], &t->cells[mid], (t->count - mid) * objcell_size);
 	t->cells = c;
 	t->count++;
 }

--- a/vm/objtable.h
+++ b/vm/objtable.h
@@ -54,11 +54,11 @@ static INLINE value otable_get(objtable *t,field id) {
 	int min;
 	int max;
 	int mid;
-	objcell *c;
+	const objcell *c;
 	field cid;
 	min = 0;
 	max = t->count;
-	c = t->cells;
+	c = (const objcell*)t->cells;
 	while( min < max ) {
 		mid = (min + max) >> 1;
 		cid = c[mid].id;

--- a/vm/others.c
+++ b/vm/others.c
@@ -145,7 +145,7 @@ static void buffer_append_new( buffer b, const char *s, int len ) {
 	it->size = size;
 	it->len = len;
 	it->next = b->data;
-	b->data = it;	
+	b->data = it;
 }
 
 EXTERN void buffer_append_sub( buffer b, const char *s, int_val _len ) {
@@ -182,7 +182,7 @@ EXTERN void buffer_append_char( buffer b, char c ) {
 	b->totlen++;
 	it = b->data;
 	if( it && it->len != it->size ) {
-		it->str[it->len++] = c;		
+		it->str[it->len++] = c;
 		return;
 	}
 	buffer_append_new(b,&c,1);
@@ -418,19 +418,11 @@ EXTERN field val_id( const char *name ) {
 			objcell *c2 = (objcell*)alloc(sizeof(objcell)*(t->count+1));
 
 			// copy the whole table
-			mid = (min + max) >> 1;
-			min = 0;
-			while( min < mid ) {
-				c2[min] = c[min];
-				min++;
-			}
-			c2[min].id = f;
-			c2[min].v = copy_string(oname,name - oname);
-			max = t->count;
-			while( min < max ) {
-				c2[min+1] = c[min];
-				min++;
-			}
+            mid = (min + max) >> 1;
+            memcpy(c2, c, (void*)&c[mid] - (void*)c);
+			c2[mid].id = f;
+			c2[mid].v = copy_string(oname,name - oname);
+            memcpy(&c2[mid + 1], &c[mid], (void*)&c[t->count] - (void*)&c[mid]);
 
 			// update
 			t->cells = c2;

--- a/vm/others.c
+++ b/vm/others.c
@@ -415,14 +415,15 @@ EXTERN field val_id( const char *name ) {
 		}
 		// in case we found it, it means that it's been inserted by another thread
 		if( fdata == val_null ) {
-			objcell *c2 = (objcell*)alloc(sizeof(objcell)*(t->count+1));
+            const size_t objcell_size = sizeof(objcell);
+			objcell *c2 = (objcell*)alloc(objcell_size * (t->count + 1));
 
 			// copy the whole table
             mid = (min + max) >> 1;
-            memcpy(c2, c, (void*)&c[mid] - (void*)c);
+            memcpy(c2, c, mid * objcell_size);
 			c2[mid].id = f;
 			c2[mid].v = copy_string(oname,name - oname);
-            memcpy(&c2[mid + 1], &c[mid], (void*)&c[t->count] - (void*)&c[mid]);
+            memcpy(&c2[mid + 1], &c[mid], (t->count - mid) * objcell_size);
 
 			// update
 			t->cells = c2;

--- a/vm/others.c
+++ b/vm/others.c
@@ -415,15 +415,15 @@ EXTERN field val_id( const char *name ) {
 		}
 		// in case we found it, it means that it's been inserted by another thread
 		if( fdata == val_null ) {
-            const size_t objcell_size = sizeof(objcell);
+			const size_t objcell_size = sizeof(objcell);
 			objcell *c2 = (objcell*)alloc(objcell_size * (t->count + 1));
 
 			// copy the whole table
-            mid = (min + max) >> 1;
-            memcpy(c2, c, mid * objcell_size);
+			mid = (min + max) >> 1;
+			memcpy(c2, c, mid * objcell_size);
 			c2[mid].id = f;
 			c2[mid].v = copy_string(oname,name - oname);
-            memcpy(&c2[mid + 1], &c[mid], (t->count - mid) * objcell_size);
+			memcpy(&c2[mid + 1], &c[mid], (t->count - mid) * objcell_size);
 
 			// update
 			t->cells = c2;


### PR DESCRIPTION
Given the `mem*` calls, this code:

```haxe
class Debug
{
    public static function main():Void
    {
        for (i in 0...10) {
            var arr = [  { age: 18 } ];
            for (i in 0...500000) {
                arr.push({ age: i });
                arr[i].age = i + 10;
            }
            for (i in 0...500000) {
                arr.slice(i, 1);
            }
        }
    }
}
```

went from 9600 to 8100 (measured with `time` command).

Of course this code somehow forces that, but it is definitely faster anyway.

Beside that, the `unsigned int`s are never negative without explicit casting.