### PR TITLE
allow for package manager defaults (brew on osx)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,11 @@ endif
 
 ### OSX SPECIFIC
 
+
+ifeq (${package_manager}, brew)
+LIB_PREFIX = $(shell brew --prefix)
+endif
+
 ifeq (${os}, osx)
 export MACOSX_DEPLOYMENT_TARGET=10.4
 EXTFLAGS =


### PR DESCRIPTION
This would allow us to set library locations based on parameters set by package managers, etc.  Right now they seem to be hard coded.

E.g., the specification for homebrew on osx would be:

```make os=osx package_manager=brew```
