### PR TITLE
Enable FreeBSD builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@
 # For MingW/MSys
 #   make os=mingw
 #
+# For FreeBSD
+#   gmake os=freebsd
+#
 
 ## CONFIG
 
@@ -21,8 +24,9 @@ NEKOVM_FLAGS = -Lbin -lneko
 STD_NDLL_FLAGS = ${NEKOVM_FLAGS} -lrt
 INSTALL_FLAGS =
 LIB_PREFIX = /opt/local
+INSTALL_ENV =
 
-NEKO_EXEC = LD_LIBRARY_PATH=../bin:${LD_LIBRARY_PATH} NEKOPATH=../boot:../bin ../bin/neko
+NEKO_EXEC = ${INSTALL_ENV} LD_LIBRARY_PATH=../bin:${LD_LIBRARY_PATH} NEKOPATH=../boot:../bin ../bin/neko
 
 # For profiling VM
 #
@@ -56,6 +60,17 @@ NEKOVM_FLAGS = -L${CURDIR}/bin -lneko
 STD_NDLL_FLAGS = -bundle -undefined dynamic_lookup ${NEKOVM_FLAGS}
 CFLAGS += -L/usr/local/lib -L${LIB_PREFIX}/lib -I${LIB_PREFIX}/include
 INSTALL_FLAGS = -static
+
+endif
+
+### FreeBSD SPECIFIC
+
+ifeq (${os}, freebsd)
+INSTALL_PREFIX = /usr/local
+LIB_PREFIX = /usr/local
+LIBNEKO_LIBS = -L${LIB_PREFIX}/lib -lgc-threaded -lm
+CFLAGS += -I${LIB_PREFIX}/include
+INSTALL_ENV = CC=cc
 
 endif
 

--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ Note that you may need to install "Microsoft Visual C++ 2010 Redistributable Pac
 
 ### Linux
 Install the libgc-dev dependency, then build from source.
+
+### FreeBSD
+Install the devel/boehm-gc-threaded port or corresponding package, then build from source. See Makefile for additional instructions.
+

--- a/libs/std/process.c
+++ b/libs/std/process.c
@@ -27,7 +27,7 @@
 #	include <sys/types.h>
 #	include <unistd.h>
 #	include <errno.h>
-#	ifndef NEKO_MAC
+#	if !defined(NEKO_MAC) && !defined(NEKO_BSD)
 #		include <wait.h>
 #	endif
 #endif

--- a/src/tools/install.neko
+++ b/src/tools/install.neko
@@ -134,7 +134,7 @@ cflags = "-O3 -fPIC";
 if( system == "Linux" ) cflags += " -pthread";
 cc = getenv("CC");
 if( cc == null ) cc = "gcc";
-linkcmd = switch system { "BSD" => "ld" default => cc };
+linkcmd = cc;
 linkneko = "-lneko";
 linkoptions = switch system {
 	"Mac" => "-bundle -undefined dynamic_lookup -L../../bin"

--- a/vm/main.c
+++ b/vm/main.c
@@ -32,6 +32,10 @@
 #	include <sys/param.h>
 #	include <mach-o/dyld.h>
 #endif
+#ifdef NEKO_BSD
+#	include <sys/param.h>
+#	include <sys/sysctl.h>
+#endif
 #ifdef NEKO_POSIX
 #	include <signal.h>
 #endif
@@ -62,6 +66,17 @@ static char *executable_path() {
 	if ( _NSGetExecutablePath(path, &path_len) )
 		return NULL;
 	return path;
+#elif defined(NEKO_BSD)
+        int mib[4];
+        mib[0] = CTL_KERN;
+        mib[1] = KERN_PROC;
+        mib[2] = KERN_PROC_PATHNAME;
+        mib[3] = -1;
+	static char path[MAXPATHLEN];
+        size_t cb = sizeof(path);
+        sysctl(mib, 4, path, &cb, NULL, 0);
+        if (!cb) return NULL;
+        return path;
 #else
 	static char path[200];
 	int length = readlink("/proc/self/exe", path, sizeof(path));


### PR DESCRIPTION
Enabled building, installing and running on FreeBSD. Closes #80. To build do
```
$ gmake os=freebsd
```
then to install (as root):
```
# gmake os=freebsd install
```

Included changes (should only affect FreeBSD builds):
- Change install path, include path and lib path: FreeBSD expects third-party software to live in /usr/local, but does not search /usr/local for libraries and includes by default
- Make a note in README, libgc dependency is devel/boehm-gc-threaded
- Use cc instead of gcc for compilation, and instead of ld for linking
- Use a syscall instead of reading /proc/self/exe to get path to executable