### PR TITLE
Install process improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,9 @@ endif
 ### FreeBSD SPECIFIC
 
 ifeq (${os}, freebsd)
-INSTALL_PREFIX = /usr/local
-LIB_PREFIX = /usr/local
+PREFIX = /usr/local
+INSTALL_PREFIX = $(PREFIX)
+LIB_PREFIX = $(PREFIX)
 LIBNEKO_LIBS = -L${LIB_PREFIX}/lib -lgc-threaded -lm
 CFLAGS += -I${LIB_PREFIX}/include
 INSTALL_ENV = CC=cc

--- a/Makefile
+++ b/Makefile
@@ -132,9 +132,9 @@ clean:
 install:
 	cp bin/${LIBNEKO_NAME} ${INSTALL_PREFIX}/lib
 	cp bin/neko bin/nekoc bin/nekotools bin/nekoml bin/nekoml.std ${INSTALL_PREFIX}/bin
-	-mkdir ${INSTALL_PREFIX}/lib/neko
+	mkdir -p ${INSTALL_PREFIX}/lib/neko
 	cp bin/*.ndll ${INSTALL_PREFIX}/lib/neko
-	-mkdir ${INSTALL_PREFIX}/include
+	mkdir -p ${INSTALL_PREFIX}/include
 	cp vm/neko*.h ${INSTALL_PREFIX}/include
 	chmod o+rx,g+rx ${INSTALL_PREFIX}/bin/neko ${INSTALL_PREFIX}/bin/nekoc ${INSTALL_PREFIX}/bin/nekotools ${INSTALL_PREFIX}/bin/nekoml ${INSTALL_PREFIX}/lib/${LIBNEKO_NAME} ${INSTALL_PREFIX}/lib/neko ${INSTALL_PREFIX}/lib/neko/*.ndll
 	chmod o+r,g+r ${INSTALL_PREFIX}/bin/nekoml.std ${INSTALL_PREFIX}/include/neko*.h

--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,8 @@ endif
 ### FreeBSD SPECIFIC
 
 ifeq (${os}, freebsd)
-PREFIX = /usr/local
-INSTALL_PREFIX = $(PREFIX)
-LIB_PREFIX = $(PREFIX)
+INSTALL_PREFIX = /usr/local
+LIB_PREFIX = /usr/local
 LIBNEKO_LIBS = -L${LIB_PREFIX}/lib -lgc-threaded -lm
 CFLAGS += -I${LIB_PREFIX}/include
 INSTALL_ENV = CC=cc

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,14 @@ install:
 	chmod o+rx,g+rx ${INSTALL_PREFIX}/bin/neko ${INSTALL_PREFIX}/bin/nekoc ${INSTALL_PREFIX}/bin/nekotools ${INSTALL_PREFIX}/bin/nekoml ${INSTALL_PREFIX}/lib/${LIBNEKO_NAME} ${INSTALL_PREFIX}/lib/neko ${INSTALL_PREFIX}/lib/neko/*.ndll
 	chmod o+r,g+r ${INSTALL_PREFIX}/bin/nekoml.std ${INSTALL_PREFIX}/include/neko*.h
 
+install-strip: install
+	strip ${INSTALL_PREFIX}/bin/neko
+	strip ${INSTALL_PREFIX}/bin/nekoc
+	strip ${INSTALL_PREFIX}/bin/nekotools
+	strip ${INSTALL_PREFIX}/bin/nekoml
+	strip ${INSTALL_PREFIX}/lib/libneko.so
+	strip ${INSTALL_PREFIX}/lib/neko/*.ndll
+
 uninstall:
 	rm -rf ${INSTALL_PREFIX}/lib/${LIBNEKO_NAME}
 	rm -rf ${INSTALL_PREFIX}/bin/neko ${INSTALL_PREFIX}/bin/nekoc ${INSTALL_PREFIX}/bin/nekotools 

--- a/libs/std/process.c
+++ b/libs/std/process.c
@@ -27,8 +27,12 @@
 #	include <sys/types.h>
 #	include <unistd.h>
 #	include <errno.h>
-#	if !defined(NEKO_MAC) && !defined(NEKO_BSD)
-#		include <wait.h>
+#	if !defined(NEKO_MAC)
+#		if defined(NEKO_BSD)
+#			include <sys/wait.h>
+#		else
+#			include <wait.h>
+#		endif
 #	endif
 #endif
 


### PR DESCRIPTION
This came up when I was trying to create a FreeBSD port for Neko. #84 

0. Added install-strip target that is useful when there is a requirement for installing stripped binaries.
1. Unless there is a reason not to use it, mkdir -p is cleaner than getting an error, but ignoring it.
