### PR TITLE
GNU Makefile convention

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,12 @@ install:
 script:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
         make;
+        make test;
         sudo make install;
     elif [ "${TRAVIS_OS_NAME}" = "osx" ]; then
         make os=osx LIB_PREFIX=/usr/local;
+        make test;
         sudo make os=osx install;
     fi
   - neko -version
-  - make test
+  - neko src/tools/test.n

--- a/src/tools/install.neko
+++ b/src/tools/install.neko
@@ -130,13 +130,17 @@ while( i < $asize($loader.args) ) {
 
 // PLATFORM
 
-cflags = "-O3 -fPIC";
-if( system == "Linux" ) cflags += " -pthread";
+cflags = getenv("CFLAGS");
+if( cflags == null ) {
+	cflags = "-O3 -fPIC";
+	if( system == "Linux" ) cflags += " -pthread";
+}
 cc = getenv("CC");
 if( cc == null ) cc = "gcc";
 linkcmd = cc;
 linkneko = "-lneko";
-linkoptions = switch system {
+linkoptions = getenv("LDFLAGS");
+if( linkoptions == null ) linkoptions = switch system {
 	"Mac" => "-bundle -undefined dynamic_lookup -L../../bin"
 	default => "-shared -L../../bin -pthread"
 };


### PR DESCRIPTION
In order to help create and maintain packaging across *inx systems, I refined the Makefile according to some of the [GNU Makefile convention](https://www.gnu.org/prep/standards/html_node/Makefile-Conventions.html#Makefile-Conventions).

 * `CFLAGS`/`LDFLAGS` are commonly defined in a way that they can be completely overridden by users. It means that the default values of them in the Makefile should be optional. See https://www.gnu.org/prep/standards/html_node/Command-Variables.html#Command-Variables.
 * Added standard directory variables for install related targets. See https://www.gnu.org/prep/standards/html_node/Directory-Variables.html#Directory-Variables
 * Moved strip commands to the install-strip target. (@kulick please check if that is ok for you) See https://www.gnu.org/prep/standards/html_node/Standard-Targets.html#Standard-Targets