### PR TITLE
improves install.neko

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,8 @@ NEKOVM_FLAGS = -Lbin -lneko
 STD_NDLL_FLAGS = ${NEKOVM_FLAGS} -lrt
 INSTALL_FLAGS =
 LIB_PREFIX = /opt/local
-INSTALL_ENV =
 
-NEKO_EXEC = ${INSTALL_ENV} LD_LIBRARY_PATH=../bin:${LD_LIBRARY_PATH} NEKOPATH=../boot:../bin ../bin/neko
+NEKO_EXEC = LD_LIBRARY_PATH=../bin:${LD_LIBRARY_PATH} NEKOPATH=../boot:../bin ../bin/neko
 NEKO_BIN_LINKER_FLAGS = -Wl,-rpath,'$$ORIGIN',--enable-new-dtags
 
 # For profiling VM
@@ -91,7 +90,7 @@ INSTALL_PREFIX = /usr/local
 LIB_PREFIX = /usr/local
 LIBNEKO_LIBS = -L${LIB_PREFIX}/lib -lgc-threaded -lm
 INCLUDE_FLAGS += -I${LIB_PREFIX}/include
-INSTALL_ENV = CC=cc
+INSTALL_FLAGS = -cc cc
 
 endif
 
@@ -114,7 +113,7 @@ libs:
 
 tools:
 	(cd src; ${NEKO_EXEC} nekoc tools/install.neko)
-	(cd src; ${NEKO_EXEC} tools/install -nolibs)
+	(cd src; ${NEKO_EXEC} tools/install -nolibs ${INSTALL_FLAGS})
 
 doc:
 	(cd src; ${NEKO_EXEC} nekoc tools/makedoc.neko)

--- a/src/tools/install.neko
+++ b/src/tools/install.neko
@@ -126,18 +126,37 @@ while( i < $asize($loader.args) ) {
 	switch $loader.args[i] {
 		"-silent" =>
 			silent = true
+
 		"-static" => {
 			libs.regexp.lparams = null;
 			libs.regexp.lib = "libpcre.a";
 			libs.zlib.lparams = null;
 			libs.zlib.lib = "libz.a";
 		}
+
 		"-nolibs" =>
 			libs = $new(null)
+
+		// Libs (comma-seperated) to be built.
+		// The lib names are the fields of libs above.
+		// By default all libs will be built.
+		"-libs" => {
+			i = i + 1;
+			var libs_list = split($loader.args[i], ",");
+			var new_libs = $new(null)
+			while( libs_list != null ) {
+				var field_hash = $hash(libs_list[0]);
+				$objset(new_libs, field_hash, $objget(libs, field_hash));
+				libs_list = libs_list[1];
+			}
+			libs = new_libs;
+		}
+
 		"-cc" => {
 			i = i + 1;
 			cc = $loader.args[i];
 		}
+
 		"-cflags" => {
 			i = i + 1;
 			cflags = $loader.args[i];
@@ -146,6 +165,7 @@ while( i < $asize($loader.args) ) {
 			i = i + 1;
 			linkoptions = $loader.args[i];
 		}
+
 		"-append-cflags" => {
 			i = i + 1;
 			cflags += " " + $loader.args[i];

--- a/src/tools/install.neko
+++ b/src/tools/install.neko
@@ -34,7 +34,6 @@ exists = $loader.loadprim("std@sys_exists",1);
 split = $loader.loadprim("std@string_split",2);
 mkdir = $loader.loadprim("std@sys_create_dir",2);
 delete = $loader.loadprim("std@file_delete",1);
-getenv = $loader.loadprim("std@get_env",1);
 
 buffer_new = $loader.loadprim("std@buffer_new",0);
 buffer_add_char = $loader.loadprim("std@buffer_add_char",2);
@@ -111,39 +110,58 @@ libs = {
 }
 
 var silent = false;
+
+var cc = "gcc";
+
+var cflags = "-O3 -fPIC";
+if( system == "Linux" ) cflags += " -pthread";
+
+var linkoptions = switch system {
+	"Mac" => "-bundle -undefined dynamic_lookup -L../../bin"
+	default => "-shared -L../../bin -pthread"
+};
+
 var i = 0;
 while( i < $asize($loader.args) ) {
 	switch $loader.args[i] {
-	"-silent" =>
-		silent = true
-	"-static" => {
-		libs.regexp.lparams = null;
-		libs.regexp.lib = "libpcre.a";
-		libs.zlib.lparams = null;
-		libs.zlib.lib = "libz.a";
-	}
-	"-nolibs" =>
-		libs = $new(null)
+		"-silent" =>
+			silent = true
+		"-static" => {
+			libs.regexp.lparams = null;
+			libs.regexp.lib = "libpcre.a";
+			libs.zlib.lparams = null;
+			libs.zlib.lib = "libz.a";
+		}
+		"-nolibs" =>
+			libs = $new(null)
+		"-cc" => {
+			i = i + 1;
+			cc = $loader.args[i];
+		}
+		"-cflags" => {
+			i = i + 1;
+			cflags = $loader.args[i];
+		}
+		"-ldflags" => {
+			i = i + 1;
+			linkoptions = $loader.args[i];
+		}
+		"-append-cflags" => {
+			i = i + 1;
+			cflags += " " + $loader.args[i];
+		}
+		"-append-ldflags" => {
+			i = i + 1;
+			linkoptions += " " + $loader.args[i];
+		}
 	}
 	i = i + 1;
 }
 
 // PLATFORM
 
-cflags = getenv("CFLAGS");
-if( cflags == null ) {
-	cflags = "-O3 -fPIC";
-	if( system == "Linux" ) cflags += " -pthread";
-}
-cc = getenv("CC");
-if( cc == null ) cc = "gcc";
 linkcmd = cc;
 linkneko = "-lneko";
-linkoptions = getenv("LDFLAGS");
-if( linkoptions == null ) linkoptions = switch system {
-	"Mac" => "-bundle -undefined dynamic_lookup -L../../bin"
-	default => "-shared -L../../bin -pthread"
-};
 nekovm = switch system { "Windows" => "..\\bin\\neko" default => "../bin/neko" };
 
 // COMMANDS


### PR DESCRIPTION
See https://github.com/HaxeFoundation/neko/pull/92#issuecomment-157628211

It is now possible to override, as well as append new flags by making use of the `-cflags`, `-ldflags`, `-append-cflags`, `-append-ldflags` arguments.

I also added `-libs` to control which libs to be built.

All the above mentioned arguments can be set by using the `INSTALL_FLAGS` makefile variable.

