### PR TITLE
Fixed duplicate `alloc_array` in `store_table`

### DIFF
--- a/libs/mod_neko/cgi.c
+++ b/libs/mod_neko/cgi.c
@@ -203,7 +203,6 @@ static int store_table( void *r, const char *key, const char *val ) {
 	value a;
 	if( key == NULL || val == NULL )
 		return 1;
-	a = alloc_array(2);
 	a = alloc_array(3);
 	val_array_ptr(a)[0] = alloc_string(key);
 	val_array_ptr(a)[1] = alloc_string(val);


### PR DESCRIPTION
It is redundant, isn't it?