### PR TITLE
Thread safety on Windows

### DIFF
--- a/libs/include/ssl/mbedtls/config.h
+++ b/libs/include/ssl/mbedtls/config.h
@@ -1058,7 +1058,7 @@
  *
  * Comment this macro to disable support for SSL 3.0
  */
-#define MBEDTLS_SSL_PROTO_SSL3
+//#define MBEDTLS_SSL_PROTO_SSL3
 
 /**
  * \def MBEDTLS_SSL_PROTO_TLS1
@@ -1233,7 +1233,7 @@
  *
  * Uncomment this to allow your own alternate threading implementation.
  */
-//#define MBEDTLS_THREADING_ALT
+#define MBEDTLS_THREADING_ALT
 
 /**
  * \def MBEDTLS_THREADING_PTHREAD
@@ -1903,7 +1903,7 @@
  *
  * This module provides TCP/IP networking routines.
  */
-#define MBEDTLS_NET_C
+//#define MBEDTLS_NET_C
 
 /**
  * \def MBEDTLS_OID_C
@@ -2259,7 +2259,7 @@
  *
  * Enable this layer to allow use of mutexes within mbed TLS
  */
-//#define MBEDTLS_THREADING_C
+#define MBEDTLS_THREADING_C
 
 /**
  * \def MBEDTLS_TIMING_C

--- a/libs/include/ssl/mbedtls/threading_alt.h
+++ b/libs/include/ssl/mbedtls/threading_alt.h
@@ -1,0 +1,7 @@
+#include <windows.h>
+
+typedef struct
+{
+    CRITICAL_SECTION cs;
+	char is_valid;
+} mbedtls_threading_mutex_t;


### PR DESCRIPTION
This adds support for thread safe SSL contexts sharing on Windows.

If necessary, the mbedTLS lib can be recompiled directly using this fork : https://github.com/pperidont/mbedtls/tree/neko_windows