### PR TITLE
Add include of mbedtls/platform.h to get SSL library to build on plat…

### DIFF
--- a/libs/ssl/ssl.c
+++ b/libs/ssl/ssl.c
@@ -22,6 +22,7 @@ typedef int SOCKET;
 #define SOCKET_ERROR (-1)
 #define NRETRYS	20
 
+#include "mbedtls/platform.h"
 #include "mbedtls/error.h"
 #include "mbedtls/entropy.h"
 #include "mbedtls/ctr_drbg.h"


### PR DESCRIPTION
…forms that have mbedtls_time_t type defined.

On Linux (at least in latest version) mbedtls is using time_t for the timestamps, while on some other platforms (BSD) it has a typedef mbedtls_type_t that is defined in mbedtls/platform.h

Including that header would not break anything for platform using time_t, but will enable building on the ones with mbedtls_time_t.
