### PR TITLE
CMake: pass the lib install dir to ldconfig

### DIFF
--- a/cmake/ldconfig.cmake
+++ b/cmake/ldconfig.cmake
@@ -1,7 +1,7 @@
 # Detect if the install is run by CPack.
 if (NOT CMAKE_INSTALL_PREFIX MATCHES "/_CPack_Packages/.*/(TGZ|ZIP)/")
 	message(STATUS "Running: ldconfig")
-	execute_process(COMMAND "ldconfig" RESULT_VARIABLE ldconfig_result)
+	execute_process(COMMAND "ldconfig" "${CMAKE_INSTALL_PREFIX}/lib" RESULT_VARIABLE ldconfig_result)
 	if (NOT ldconfig_result EQUAL 0)
 		message(WARNING "ldconfig failed")
 	endif()


### PR DESCRIPTION
`ldconfig` by default only checks `/lib` and `/usr/lib` (and its `*64`
variants).