### PR TITLE
make sure path folders have a trailing slash

### DIFF
--- a/src/tools/nekoboot.neko
+++ b/src/tools/nekoboot.neko
@@ -195,7 +195,6 @@ var find_exe_in_path = function(path,file) {
 				if ( last != "/" || last != "\\" )
 					p = p + "/";
 			}
-			var p = path[0];
 			var s = file_contents(p + file);
 			if( $sget(s,0) == 35 ) // '#'
 				$throw("Is a script");

--- a/src/tools/nekoboot.neko
+++ b/src/tools/nekoboot.neko
@@ -141,7 +141,7 @@ int main( int argc, char *argv[] ) {
 	neko_global_init();
 	vm = neko_vm_alloc(NULL);
 	neko_vm_select(vm);
-	
+
 	mload = default_loader(argv+1,argc-1);
 	r = neko_execute_self(vm,mload);
 	if( mload != NULL && val_field(mload,val_id(\"dump_prof\")) != val_null )
@@ -188,7 +188,15 @@ var find = function(str,sub,pos) {
 var find_exe_in_path = function(path,file) {
 	while( path != null ) {
 		try {
-			var s = file_contents(path[0]+file);
+			var p = path[0];
+			var l = $ssize(p);
+			if ( l > 0 ) { // add trailing slash
+				var last = $ssub(p,l-1,1);
+				if ( last != "/" || last != "\\" )
+					p = p + "/";
+			}
+			var p = path[0];
+			var s = file_contents(p + file);
 			if( $sget(s,0) == 35 ) // '#'
 				$throw("Is a script");
 			return s;


### PR DESCRIPTION
this pr fixes the problems that i encountered here: https://github.com/HaxeFoundation/haxe/issues/5216#issuecomment-252288104.
Every folder inside the PATH Variable was concatenated with "neko" without checking for a trailing slash. This behaviour caused `file_contents` calls for files like `/usr/libneko` instead of `/usr/lib/neko`.
I didn't checked this on windows, but i guess "/" separators should work there too.