### PR TITLE
Handled case for MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY

### DIFF
--- a/libs/ssl/ssl.c
+++ b/libs/ssl/ssl.c
@@ -242,6 +242,8 @@ static value ssl_recv( value ssl, value data, value pos, value len ) {
 		HANDLE_EINTR(recv_again);
 		return block_error();
 	}
+	if( dlen == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY )
+		return alloc_int(0);
 	if( dlen < 0 )
 		neko_error();
 	return alloc_int( dlen );

--- a/libs/ssl/ssl.c
+++ b/libs/ssl/ssl.c
@@ -264,6 +264,8 @@ static  value ssl_read( value ssl ) {
 			HANDLE_EINTR(read_again);
 			return block_error();
 		}
+		if( len == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY )
+			break;
 		if( len == 0 )
 			break;
 		buffer_append_sub(b,(const char *)buf,len);


### PR DESCRIPTION
On the Pakka Pets server we use HTTP.hx to print Facebook to verify user. This case happens 100% of the time after all of the data is read from the buffer.

I couldn't find much online about `MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY`. This at a glance looks reputable, and they handle the case similarly.

https://github.com/ARMmbed/mbedtls/blob/788aa4a81214fa1d13b723e63a1e5b728b614771/programs/ssl/dtls_client.c#L287
