### PR TITLE
Fix mysql_select_db

### DIFF
--- a/libs/mysql/my_proto/my_api.c
+++ b/libs/mysql/my_proto/my_api.c
@@ -254,7 +254,7 @@ int mysql_select_db( MYSQL *m, const char *dbname ) {
 	int pcount = 0;
 	myp_begin_packet(p,0);
 	myp_write_byte(p,COM_INIT_DB);
-	myp_write_string(p,dbname);
+	myp_write_string_eof(p,dbname);
 	if( !myp_send_packet(m,p,&pcount) ) {
 		error(m,"Failed to send packet",NULL);
 		return -1;

--- a/libs/mysql/my_proto/my_proto.c
+++ b/libs/mysql/my_proto/my_proto.c
@@ -220,6 +220,10 @@ void myp_write_string( MYSQL_PACKET *p, const char *str ) {
 	myp_write(p,str,strlen(str) + 1);
 }
 
+void myp_write_string_eof( MYSQL_PACKET *p, const char *str ) {
+	myp_write(p,str,strlen(str));
+}
+
 void myp_write_bin( MYSQL_PACKET *p, int size ) {
 	if( size <= 250 ) {
 		unsigned char l = (unsigned char)size;

--- a/libs/mysql/my_proto/my_proto.h
+++ b/libs/mysql/my_proto/my_proto.h
@@ -164,6 +164,7 @@ void myp_write_ui16( MYSQL_PACKET *p, int b );
 void myp_write_int( MYSQL_PACKET *p, int b );
 
 void myp_write_string( MYSQL_PACKET *p, const char *str );
+void myp_write_string_eof( MYSQL_PACKET *p, const char *str );
 void myp_write_bin( MYSQL_PACKET *p, int size );
 
 // passwords


### PR DESCRIPTION
MySQL protocol reference for COM_INIT_DB is here : 
https://dev.mysql.com/doc/internals/en/com-init-db.html

The select_db with a zero terminated string was working, but could produce errors in replication of some statements (DELETE TEMPORARY TABLE for example)