### PR TITLE
Correct spelling when invalid char is received in nekotools server

### DIFF
--- a/src/tools/WebServer.nml
+++ b/src/tools/WebServer.nml
@@ -597,7 +597,7 @@ function client_msg_safe(c) {
 	try {
 		client_msg(c);
 	} catch {
-		| Invalid_char -> printf "Invalid char reveived\n" ();
+		| Invalid_char -> printf "Invalid char received\n" ();
 		| IO.Eof -> printf "Connection aborted\n" ();
 		| Neko_error e when Reflect.value e == Reflect.VString "std@socket_send" -> printf "Sending file aborted\n" ();
 	}


### PR DESCRIPTION
This has been long overdue, wanted to help see this resolved :smile: