### PR TITLE
ignore .nekobytecode section if it is too small

### DIFF
--- a/vm/main.c
+++ b/vm/main.c
@@ -115,9 +115,9 @@ int neko_has_embedded_module( neko_vm *vm ) {
 		return 0;
 
 #ifdef SEPARATE_SECTION_FOR_BYTECODE
-	/* Look for a ,nekobytecode section in the executable... */
-	if ( val_true != elf_find_embedded_bytecode(exe,&beg,&end) ) {
-		/* Couldn't find a .nekobytecode section,
+	/* Look for a .nekobytecode section in the executable..., there is always a small section */
+	if ( val_true != elf_find_embedded_bytecode(exe,&beg,&end) || end-beg <= 8) {
+		/* Couldn't find a big enough .nekobytecode section,
 		   fallback to looking at the end of the executable... */
 		beg = -1; end = 0;
 	}


### PR DESCRIPTION
There is regression after [this commit](https://github.com/HaxeFoundation/neko/commit/df70fc1c116cdda0d266fe57d1183fb8e9737a41) (also related tickets: https://github.com/HaxeFoundation/neko/pull/75 and https://github.com/HaxeFoundation/neko/pull/86).

After the commit, ```neko``` executable always has ```.nekobytecode``` section and ```elf_find_embedded_bytecode()``` always succeed.
The old-style bundles (with 'NEKOxxxx' at the end, which are still [produced by NME](https://github.com/haxenme/nme/blob/master/tools/nme/src/helpers/NekoHelper.hx#L31)) no more work.

By default the section is too small to contain meaningful bytecode (on my x86_64 Linux it has size from ```-4``` to ```4``` bytes) so I decided to add the sanity check and consider a section which is less than 8 bytes as a not found one.