### PR TITLE
Fixed sha1_update call

### DIFF
--- a/libs/std/md5.c
+++ b/libs/std/md5.c
@@ -383,7 +383,7 @@ static value make_sha1( value s, value p, value l ) {
 	if( pp < 0 || ll < 0 || pp + ll < 0 || pp + ll > val_strlen(s) )
 		neko_error();
 	sha1_init(&ctx);
-	sha1_update(&ctx,(unsigned char*)val_string(l)+pp,ll);
+	sha1_update(&ctx,(unsigned char*)val_string(s)+pp,ll);
 	sha1_final(&ctx,result);
 	return copy_string( (char*)result, sizeof(SHA1_DIGEST) );
 }


### PR DESCRIPTION
Fixed issue in #186 .

Passing l, an int value of length, instead of the s string through the function causes a segfault.