### PR TITLE
Keep reference to k_db abstract and avoid early finalizer call

### DIFF
--- a/libs/sqlite/sqlite.c
+++ b/libs/sqlite/sqlite.c
@@ -45,7 +45,7 @@ typedef struct _database {
 } database;
 
 typedef struct _result {
-	database *db;
+	value database;
 	int ncols;
 	int count;
 	field *names;
@@ -65,12 +65,12 @@ static void finalize_result( result *r, int exc ) {
 	r->first = 0;
 	r->done = 1;
 	if( r->ncols == 0 )
-		r->count = sqlite3_changes(r->db->db);
+		r->count = sqlite3_changes(val_db(r->database)->db);
 	if( sqlite3_finalize(r->r) != SQLITE_OK && exc )
 		val_throw(alloc_string("Could not finalize request"));
 	r->r = NULL;
-	r->db->last = NULL;
-	r->db = NULL;
+	val_db(r->database)->last = NULL;
+	r->database = NULL;
 }
 
 static void free_db( value v ) {
@@ -137,7 +137,7 @@ static value request( value v, value sql ) {
 	val_check(sql,string);
 	db = val_db(v);
 	r = (result*)alloc(sizeof(result));
-	r->db = db;
+	r->database = v;
 	if( sqlite3_prepare(db->db,val_string(sql),val_strlen(sql),&r->r,&tl) != SQLITE_OK ) {
 		buffer b = alloc_buffer("Sqlite error in ");
 		val_buffer(b,sql);
@@ -262,7 +262,7 @@ static value result_next( value v ) {
 	case SQLITE_BUSY:
 		val_throw(alloc_string("Database is busy"));
 	case SQLITE_ERROR:
-		sqlite_error(r->db->db);
+		sqlite_error(val_db(r->database)->db);
 	default:
 		neko_error();
 	}


### PR DESCRIPTION
In the SQLite CFFI library, `connect` returns an abstract Neko value, of `k_db` kind and with a finalizer set.  If the `k_result` request value only keeps a pointer to the db struct, instead of the corresponding `k_db` value, the finalizer will be called as soon as no other external
references remain to that connection, even if the request itself is still reachable.

The issue could manifest in code like (Haxe):

	var rs = Sqlite.open("db.db").request("select * from tbl");
	trace(rs.length);

Related: HaxeFoundation/haxe#8728