### PR TITLE
[CI] fix mac image

### DIFF
--- a/extra/azure-pipelines/build-mac.yml
+++ b/extra/azure-pipelines/build-mac.yml
@@ -1,6 +1,6 @@
 parameters:
   name: 'BuildMac'
-  vmImage: 'macOS-10.13'
+  vmImage: 'macOS-10.14'
   staticDeps: 'true'
   config: 'RelWithDebInfo'
 


### PR DESCRIPTION
macOS X High Sierra 10.13 (macOS-10.13) was removed from Azure Pipelines hosted images
[soruce](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops)