### PR TITLE
Fix MSG_NOSIGNAL warning on MacOS 11

### DIFF
--- a/libs/common/socket.c
+++ b/libs/common/socket.c
@@ -47,7 +47,7 @@
 #	define HANDLE_EINTR(x)	if( errno == EINTR ) goto x
 #endif
 
-#if defined(OS_WINDOWS) || defined(OS_MAC)
+#ifndef MSG_NOSIGNAL
 #	define MSG_NOSIGNAL 0
 #endif
 

--- a/libs/std/socket.c
+++ b/libs/std/socket.c
@@ -61,7 +61,7 @@
 #	define EPOLLOUT 0x004
 #endif
 
-#if defined(NEKO_WINDOWS) || defined(NEKO_MAC)
+#ifndef MSG_NOSIGNAL
 #	define MSG_NOSIGNAL 0
 #endif
 


### PR DESCRIPTION
As I discussed at https://github.com/HaxeFoundation/neko/issues/215#issuecomment-745617663 :
```
    libs/common/socket.c:51:10: warning: 'MSG_NOSIGNAL' macro redefined [-Wmacro-redefined]
    #       define MSG_NOSIGNAL 0
               ^
    /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/usr/include/sys/socket.h:584:9: note: previous definition is here
    #define MSG_NOSIGNAL    0x80000         /* do not generate SIGPIPE on EOF */
            ^
```
It seems most likely any system that defines `MSG_NOSIGNAL` wants to use it here, so redefining it to `0` is probably not what we want to do.