### PR TITLE
libs/ui/ui.c -- fix build errors on Xcode 12

### DIFF
--- a/libs/ui/ui.c
+++ b/libs/ui/ui.c
@@ -36,6 +36,8 @@
 #	define UIEvent		0xFFFFAA00
 #	define eCall		0x0
 enum { pFunc = 'func' };
+extern void RunApplicationEventLoop(void);
+extern void QuitApplicationEventLoop(void);
 #else
 #	include <gtk/gtk.h>
 #	include <glib.h>


### PR DESCRIPTION
```
libs/ui/ui.c:197:2: error: implicit declaration of function 'RunApplicationEventLoop' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
libs/ui/ui.c:217:2: error: implicit declaration of function 'QuitApplicationEventLoop' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
```
These APIs seem to be (semi?) private.  They exist, but in the public SDK they are only defined in CarbonEvents.h deep inside HIToolbox.  I'm not sure if there is a better fix for this, but this seems to compile OK, even if it is a little hacky.