### PR TITLE
Fix Xcode 12 build error in libs/std/process.c

### DIFF
--- a/libs/std/process.c
+++ b/libs/std/process.c
@@ -27,6 +27,7 @@
 #	include <sys/types.h>
 #	include <unistd.h>
 #	include <errno.h>
+#	include <signal.h>
 #	if !defined(NEKO_MAC)
 #		if defined(NEKO_BSD)
 #			include <sys/wait.h>


### PR DESCRIPTION
As I mentioned in https://github.com/HaxeFoundation/neko/issues/215#issuecomment-745617663
```
libs/std/process.c:461:2: error: implicit declaration of function 'kill' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
```