### PR TITLE
Add regexp_matched_num

### DIFF
--- a/libs/regexp/regexp.c
+++ b/libs/regexp/regexp.c
@@ -278,6 +278,20 @@ static value regexp_matched_pos( value o, value n ) {
 	}
 }
 
+/**
+	regexp_matched_num : 'regexp -> int
+	<doc>Return the total number of matched groups, or -1 if the regexp has not
+	been matched yet</doc>
+**/
+static value regexp_matched_num( value o ) {
+	pcredata *d;
+	val_check_kind(o,k_regexp);
+	d = PCRE(o);
+	if( val_is_null(d->str) )
+		return alloc_int(-1);
+	return alloc_int(d->nmatches);
+}
+
 void regexp_main() {
 	id_pos = val_id("pos");
 	id_len = val_id("len");	
@@ -293,6 +307,7 @@ DEFINE_PRIM(regexp_replace_all,3);
 DEFINE_PRIM(regexp_replace_fun,3);
 DEFINE_PRIM(regexp_matched,2);
 DEFINE_PRIM(regexp_matched_pos,2);
+DEFINE_PRIM(regexp_matched_num,1);
 DEFINE_ENTRY_POINT(regexp_main);
 
 /* ************************************************************************ */

--- a/libs/regexp/regexp.c
+++ b/libs/regexp/regexp.c
@@ -289,7 +289,7 @@ static value regexp_matched_num( value o ) {
 	d = PCRE(o);
 	if( val_is_null(d->str) )
 		return alloc_int(-1);
-	return alloc_int(d->nmatches);
+	return alloc_int(d->nmatchs);
 }
 
 void regexp_main() {


### PR DESCRIPTION
Part 3 of an effort to add methods to get the size of a map, and the number of captures from a regex (although thankfully, Neko already supports getting the size of a map via `$hcount`).

Part 1: https://github.com/HaxeFoundation/hashlink/pull/437
Part 2: https://github.com/HaxeFoundation/hxcpp/pull/956