### PR TITLE
[CI] Attempt to fix deploy stage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -153,6 +153,7 @@ stages:
             env:
               AWS_ACCESS_KEY_ID: $(HXBUILDS_AWS_ACCESS_KEY_ID)
               AWS_SECRET_ACCESS_KEY: $(HXBUILDS_AWS_SECRET_ACCESS_KEY)
+              AWS_EC2_METADATA_DISABLED: true
             displayName: Upload binaries
           - script: |
               set -ex
@@ -169,6 +170,7 @@ stages:
             env:
               AWS_ACCESS_KEY_ID: $(HXBUILDS_AWS_ACCESS_KEY_ID)
               AWS_SECRET_ACCESS_KEY: $(HXBUILDS_AWS_SECRET_ACCESS_KEY)
+              AWS_EC2_METADATA_DISABLED: true
             condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'))
             displayName: Update "latest"
       - job: PPA


### PR DESCRIPTION
The deploy stage is currently failing (#235).

The error was `<botocore.awsrequest.AWSRequest object at 0x7fb4b4706f40>`. I did some research and I found these:
- https://github.com/aws/aws-cli/issues/5262
- https://github.com/aws/aws-cli/issues/5623

It seems that the issue is that aws is trying to figure out the region automatically which doesn't play well with azure. Setting the `AWS_EC2_METADATA_DISABLED` variable should disable this feature, and then hopefully it should deploy properly.