### PR TITLE
Add changelog for 2.3.1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+2021-10-27 : 2.3.1
+	all : deprecated neko (see README)
+	std : fixed put_env when null is passed in (#229 https://github.com/HaxeFoundation/haxe/issues/10395)
+
 2019-10-19 : 2.3.0
 	std : added socket_set_broadcast function (#190)
 	std : fixed sha1_update call (#194)


### PR DESCRIPTION
Adds the changelog for 2.3.1, which mentions the deprecation of neko and the `put_env` bugfix.