### PR TITLE
[CI] Build neko in ubuntu 18.04

### DIFF
--- a/extra/azure-pipelines/build-linux.yml
+++ b/extra/azure-pipelines/build-linux.yml
@@ -1,6 +1,6 @@
 parameters:
   name: 'BuildLinux'
-  vmImage: 'ubuntu-20.04'
+  vmImage: 'ubuntu-18.04'
   staticDeps: 'true'
   config: 'RelWithDebInfo'
 


### PR DESCRIPTION
Building on ubuntu 20.04 is not compatible with distributions with older versions of glibc.