### PR TITLE
Fix aprutil-download dependency

### DIFF
--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -207,7 +207,7 @@ if (WITH_APACHE)
 		# Download sources for fat source archive
 		add_dependencies(download_static_deps Apache-download)
 		add_dependencies(download_static_deps APR-download)
-		if (APPLE)
+		if (NOT APPLE)
 			add_dependencies(download_static_deps APRutil-download)
 		endif()
 	else()


### PR DESCRIPTION
The `APRUtil-download` dependency is only relevant with non-apple systems due to the apple builds downloading a more up to date APR that includes the APRUtil directly. This fixes the `if()` to correctly fence-off Apple builds from attempting to download the package.