### PR TITLE
[cmake] Cleanup APRutil dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,10 +106,13 @@ set(external_deps
 	PCRE
 	Sqlite3
 	APR
-	APRutil
 	Apache
 	MbedTLS
 )
+# Mac build uses a newer version of APR which already contains APRutil
+if (NOT APPLE)
+	list(APPEND external_deps APRutil)
+endif()
 
 if (WIN32)
 	set(STATIC_DEPS_DEFAULT "all")

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Settings that allow to exclude libraries and their dependencies from the build; 
 
 Default value: `all` for Windows, `none` otherwise
 
-It defines the dependencies that should be linked statically. Can be `all`, `none`, or a list of library names (e.g. `BoehmGC;Zlib;OpenSSL;MariaDBConnector;PCRE;Sqlite3;APR;APRutil;Apache;MbedTLS`).
+It defines the dependencies that should be linked statically. Can be `all`, `none`, or a list of library names (e.g. `BoehmGC;Zlib;OpenSSL;MariaDBConnector;PCRE;Sqlite3;APR;APRutil;Apache;MbedTLS`). NOTE: On MacOS, APRutil cannot be added here as it has become part of the APR version used on MacOS builds.
 
 CMake will automatically download and build the specified dependencies into the build folder. If a library is not present in this list, it should be installed manually, and it will be linked dynamically.
 

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -179,12 +179,13 @@ if (WITH_APACHE)
 				INSTALL_COMMAND echo skip install
 			)
 			set(APACHE_INCLUDE_DIRS
-				${CMAKE_BINARY_DIR}/libs/src/install-prefix/include/apr-1
 				${CMAKE_BINARY_DIR}/libs/src/Apache/include
 				${CMAKE_BINARY_DIR}/libs/src/Apache/os/unix
 			)
 			if (APPLE)
-				list(APPEND APACHE_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/libs/src/APR/include)
+				list(APPEND APACHE_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/libs/src/install-prefix/include/apr-2)
+			else()
+				list(APPEND APACHE_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/libs/src/install-prefix/include/apr-1)
 			endif()
 			set(APACHE_LIBRARIES
 

--- a/libs/mod_neko/CMakeLists.txt
+++ b/libs/mod_neko/CMakeLists.txt
@@ -17,7 +17,10 @@ target_link_libraries(mod_neko2.ndll libneko ${APACHE_LIBRARIES})
 
 # In static Apache case build dependencies first
 if (STATIC_APACHE)
-	add_dependencies(mod_neko2.ndll Apache APR APRutil)
+	add_dependencies(mod_neko2.ndll Apache APR)
+	if (NOT APPLE)
+		add_dependencies(mod_neko2.ndll APRutil)
+	endif()
 endif()
 
 set_target_properties(mod_neko2.ndll


### PR DESCRIPTION
Make sure we don't reference APRutil on Mac, as we use a newer version of APR there which contains APRutil.