### PR TITLE
Fix pcre memory leak

### DIFF
--- a/libs/regexp/regexp.c
+++ b/libs/regexp/regexp.c
@@ -48,7 +48,6 @@ DEFINE_KIND(k_regexp);
 
 static field id_pos;
 static field id_len;
-static pcre2_match_context *match_context;
 
 /**
 	<doc>
@@ -65,7 +64,7 @@ static void free_regexp( value p ) {
 }
 
 static int do_exec( pcredata *d, const char *str, int len, int pos ) {
-	int res = pcre2_match(d->regex,str,len,pos,0,d->match_data,match_context);
+	int res = pcre2_match(d->regex,str,len,pos,0,d->match_data,NULL);
 	if( res >= 0 )
 		return 1;
 	d->str = val_null; // empty string prevents trying to access the data after a failed match
@@ -303,9 +302,6 @@ static value regexp_matched_pos( value o, value n ) {
 void regexp_main() {
 	id_pos = val_id("pos");
 	id_len = val_id("len");
-
-	match_context = pcre2_match_context_create(NULL);
-	pcre2_set_depth_limit(match_context,3500); // adapted based on Windows 1MB stack size
 }
 
 DEFINE_PRIM(regexp_new,1);


### PR DESCRIPTION
This was technically a memory leak introduced in #249, although, the structure was allocated once and required throughout the lifetime of the program. However, the context is not really needed at all anymore. Since pcre 10.30, pcre2_match no longer uses recursive function calls, so this setting should no longer be needed.

See HaxeFoundation/hashlink/pull/515

This also fixes: https://github.com/HaxeFoundation/haxe/issues/8829