### PR TITLE
Add boot -c flag to nekotools help

### DIFF
--- a/src/tools/Tools.nml
+++ b/src/tools/Tools.nml
@@ -38,10 +38,13 @@ try {
 			throw Done
 		}) , " : start a neko web server");
 		("boot", Args.String (function(_) {
+			// separated from boot -c only for help message
+		}) , "<file.n> : build a standalone executable");
+		("boot", Args.String (function(_) {
 			erase_argument();
 			neko "$loader.loadmodule('tools/nekoboot',$loader)";
 			throw Done;
-		}) , "<file.n> : build an standalone executable");
+		}) , "-c <file.n> : build a standalone c program");
 	];
 	Args.parse head decl invalid_arg;
 } catch {


### PR DESCRIPTION
Closes #226.

`nekotools boot -c` should be preferred over `nekotools boot` since it avoids all the problems mentioned in #130. Also, a properly compiled executable allows setting custom rpath values, which fixes the library loading issues mentioned in #226. Perhaps the raw boot command should be deprecated and removed from the help menu?

It now looks like this:
```
Neko Tools v1.0 - (c)2005-2022 Haxe Foundation
Usage : nekotools [options]
 Options :
  server  : start a neko web server
  boot <file.n> : build a standalone executable
  boot -c <file.n> : build a standalone c program
```