### PR TITLE
Add proper error messages for failed stack checks

### DIFF
--- a/vm/module.c
+++ b/vm/module.c
@@ -545,7 +545,7 @@ neko_module *neko_read_module( reader r, readp p, value loader ) {
 		memset(stmp,UNKNOWN,m->codesize+1);
 		if( !vm->trusted_code && !neko_check_stack(m,stmp,0,0,0) ) {
 			free(stmp);
-			ERROR();
+			failure("Stack check failed for global scope");
 		}
 		for(i=0;i<m->nglobals;i++) {
 			vfunction *f = (vfunction*)m->globals[i];
@@ -557,7 +557,7 @@ neko_module *neko_read_module( reader r, readp p, value loader ) {
 				}
 				if( !vm->trusted_code && !neko_check_stack(m,stmp,itmp,f->nargs,f->nargs) ) {
 					free(stmp);
-					ERROR();
+					failure("Stack check failed for function scope");
 				}
 				f->addr = m->code + itmp;
 				prev = itmp;


### PR DESCRIPTION
Closes #283.

Now gives a more informative error if the stack check fails, instead of the generic `Invalid module` error.

I'm not sure about what line 554 does, so I left it for now.