### PR TITLE
[ci] Fix issues due to brew package changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
           brew update
           brew uninstall --force pkg-config
           brew install pkgconf --overwrite
-          brew bundle --verbose --file="${{ matrix.BREWFILE }}"
+          brew bundle --file="${{ matrix.BREWFILE }}"
 
       - name: CMake
         run: cmake . -DSTATIC_DEPS=${{ matrix.STATIC_DEPS }} -G Ninja -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,9 @@ jobs:
         run: |
           set -ex
           brew update
-          brew bundle --file="${{ matrix.BREWFILE }}"
+          brew uninstall --force pkg-config
+          brew install pkgconf --overwrite
+          brew bundle --verbose --file="${{ matrix.BREWFILE }}"
 
       - name: CMake
         run: cmake . -DSTATIC_DEPS=${{ matrix.STATIC_DEPS }} -G Ninja -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE

--- a/extra/Brewfile-STATIC_DEPS_ALL
+++ b/extra/Brewfile-STATIC_DEPS_ALL
@@ -1,5 +1,5 @@
 brew "cmake"
 brew "ninja"
-brew "pkg-config"
+brew "pkgconf"
 brew "automake"
 brew "libtool"

--- a/extra/Brewfile-STATIC_DEPS_NONE
+++ b/extra/Brewfile-STATIC_DEPS_NONE
@@ -2,6 +2,6 @@ brew "cmake"
 brew "ninja"
 brew "pkg-config"
 brew "bdw-gc"
-brew "mariadb-connector-c"
+brew "mariadb-connector-c", link: true
 brew "mbedtls"
 brew "pcre2"


### PR DESCRIPTION
Compare with: https://github.com/HaxeFoundation/haxe/pull/11833 https://github.com/HaxeFoundation/haxe/pull/11836

We now have to link mariadb-connector-c manually to build with it since it is marked as keg-only: https://github.com/Homebrew/homebrew-core/pull/196747