### PR TITLE
[ci] Fix brew python error by upgrading mac image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
           - arch: arm64
             os: macos-14
           - arch: amd64
-            os: macos-12
+            os: macos-13
           - link_type: static
             BREWFILE: extra/Brewfile-STATIC_DEPS_ALL
             STATIC_DEPS: all


### PR DESCRIPTION
Since we were still using macos-12 which is no longer supported by homebrew, we had to build mbedtls from source which meant that python was a dependency. This caused issues since the python homebrew package conflicts with the preinstalled python version in the mac runner.

Upgrading to the macos-13 image avoids the requirement to build from source, so we avoid the python error.