### PR TITLE
[cmake] Fix building on OpenBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,11 +360,8 @@ target_link_libraries(libneko ${GC_LIBRARIES})
 target_link_libraries(nekovm libneko)
 
 if(UNIX)
-	if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
-		set(DL_LIB "dl")
-	endif()
 	find_package(Threads)
-	target_link_libraries(libneko ${DL_LIB} m ${CMAKE_THREAD_LIBS_INIT})
+	target_link_libraries(libneko ${CMAKE_DL_LIBS} m ${CMAKE_THREAD_LIBS_INIT})
 endif()
 
 set_target_properties(nekovm libneko


### PR DESCRIPTION
OpenBSD does not have libdl. CMake provides a variable
which determines whether libdl is necessary or not called
CMAKE_DL_LIBS.
