### PR TITLE
Fix building sockets code on NetBSD / OpenBSD

### DIFF
--- a/libs/common/socket.c
+++ b/libs/common/socket.c
@@ -73,7 +73,7 @@ void psock_init() {
 
 PSOCK psock_create() {
 	PSOCK s = socket(AF_INET,SOCK_STREAM,0);
-#	if defined(OS_MAC) || defined(OS_BSD)
+#	if defined(OS_MAC) || (defined(OS_BSD) && !defined(SO_NOSIGPIPE))
 	if( s != INVALID_SOCKET )
 		setsockopt(s,SOL_SOCKET,SO_NOSIGPIPE,NULL,0);
 #	endif
@@ -120,7 +120,7 @@ PHOST phost_resolve( const char *host ) {
 	PHOST ip = inet_addr(host);
 	if( ip == INADDR_NONE ) {
 		struct hostent *h;
-#	if defined(OS_WINDOWS) || defined(OS_MAC) || defined(OS_CYGWIN)
+#	if defined(OS_WINDOWS) || defined(OS_MAC) || defined(OS_CYGWIN) || defined(__NetBSD__) || defined(__OpenBSD__)
 		h = gethostbyname(host);
 #	else
 		struct hostent hbase;

--- a/libs/std/socket.c
+++ b/libs/std/socket.c
@@ -371,7 +371,7 @@ static value host_resolve( value host ) {
 	ip = inet_addr(val_string(host));
 	if( ip == INADDR_NONE ) {
 		struct hostent *h;
-#	if defined(NEKO_WINDOWS) || defined(NEKO_MAC) || defined(NEKO_CYGWIN)
+#	if defined(NEKO_WINDOWS) || defined(NEKO_MAC) || defined(NEKO_CYGWIN) || defined(__NetBSD__) || defined(__OpenBSD__)
 		h = gethostbyname(val_string(host));
 #	else
 		struct hostent hbase;


### PR DESCRIPTION
NetBSD / OpenBSD does not have gethostbyname_r().

OpenBSD does not have SO_NOSIGPIPE.