### PR TITLE
[std] Prevent process stdin being closed twice

### DIFF
--- a/libs/std/process.c
+++ b/libs/std/process.c
@@ -82,7 +82,9 @@ static void free_process( value vp ) {
 #	ifdef NEKO_WINDOWS
 	CloseHandle(p->eread);
 	CloseHandle(p->oread);
-	CloseHandle(p->iwrite);
+	if (p->iwrite != NULL) {
+		CloseHandle(p->iwrite);
+	}
 	CloseHandle(p->pinf.hProcess);
 	CloseHandle(p->pinf.hThread);
 #	else
@@ -371,6 +373,7 @@ static value process_stdin_close( value vp ) {
 #	ifdef NEKO_WINDOWS
 	if( !CloseHandle(p->iwrite) )
 		neko_error();
+	p->iwrite = NULL;
 #	else
 	if( do_close(p->iwrite) )
 		neko_error();


### PR DESCRIPTION
When running `process_stdin_close`, the handle is made available again and may be reused in another part of the program. This means that it is not safe to rerun CloseHandle in free_process, since that could cause us to close a handle that no longer belongs to the process.