### PR TITLE
Do not free globals when threads are enabled

### DIFF
--- a/vm/main.c
+++ b/vm/main.c
@@ -340,7 +340,13 @@ int main( int argc, char *argv[] ) {
 	vm = NULL;
 	mload = NULL;
 	neko_vm_select(NULL);
+	#ifdef NEKO_THREADS
+	/* With threads enabled, other threads may crash if globals are freed,
+	   so only do a garbage collection there. */
+	neko_gc_major();
+	#else
 	neko_global_free();
+	#endif
 	return r;
 }
 


### PR DESCRIPTION
When threads are enabled, it's possible that other threads are still running while neko is shutting down. This means freeing builtins or the thread local storage slot for the vm context may cause a crash on those threads.

Closes #281.