### PR TITLE
[ci] upgrade macOS runners.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,9 +80,9 @@ jobs:
         link_type: [static, dynamic]
         include:
           - arch: arm64
-            os: macos-14
+            os: macos-latest
           - arch: amd64
-            os: macos-13
+            os: macos-15-intel
           - link_type: static
             BREWFILE: extra/Brewfile-STATIC_DEPS_ALL
             STATIC_DEPS: all


### PR DESCRIPTION
- use macos-latest for arm64 builds
- use macos-15-intel for x86_64 builds
  - [macos-13 will begin deprecation on September 22nd and will be fully unsupported by December 4th](https://github.com/actions/runner-images/issues/13046)
  - [macos-15-intel will be available until August 2027](https://github.com/actions/runner-images/issues/13045)
