### PR TITLE
[cmake] Disallow undefined symbols in most ndlls

### DIFF
--- a/libs/regexp/CMakeLists.txt
+++ b/libs/regexp/CMakeLists.txt
@@ -78,6 +78,10 @@ set_target_properties(regexp.ndll
 	SUFFIX .ndll
 )
 
+if (UNIX AND NOT APPLE)
+	target_link_options(regexp.ndll PRIVATE "-Wl,--no-undefined")
+endif()
+
 install (
 	TARGETS regexp.ndll
 	DESTINATION ${DEST_NDLL}

--- a/libs/sqlite/CMakeLists.txt
+++ b/libs/sqlite/CMakeLists.txt
@@ -40,6 +40,10 @@ set_target_properties(sqlite.ndll
 	SUFFIX .ndll
 )
 
+if (UNIX AND NOT APPLE)
+	target_link_options(sqlite.ndll PRIVATE "-Wl,--no-undefined")
+endif()
+
 install (
 	TARGETS sqlite.ndll
 	DESTINATION ${DEST_NDLL}

--- a/libs/ssl/CMakeLists.txt
+++ b/libs/ssl/CMakeLists.txt
@@ -78,6 +78,10 @@ set_target_properties(ssl.ndll
 	SUFFIX .ndll
 )
 
+if (UNIX AND NOT APPLE)
+	target_link_options(ssl.ndll PRIVATE "-Wl,--no-undefined")
+endif()
+
 install (
 	TARGETS ssl.ndll
 	DESTINATION ${DEST_NDLL}

--- a/libs/std/CMakeLists.txt
+++ b/libs/std/CMakeLists.txt
@@ -39,6 +39,10 @@ set_target_properties(std.ndll
 	SUFFIX .ndll
 )
 
+if (UNIX AND NOT APPLE)
+	target_link_options(std.ndll PRIVATE "-Wl,--no-undefined")
+endif()
+
 install (
 	TARGETS std.ndll
 	DESTINATION ${DEST_NDLL}

--- a/libs/ui/CMakeLists.txt
+++ b/libs/ui/CMakeLists.txt
@@ -26,6 +26,10 @@ set_target_properties(ui.ndll
 	SUFFIX .ndll
 )
 
+if (UNIX AND NOT APPLE)
+	target_link_options(ui.ndll PRIVATE "-Wl,--no-undefined")
+endif()
+
 install (
 	TARGETS ui.ndll
 	DESTINATION ${DEST_NDLL}

--- a/libs/zlib/CMakeLists.txt
+++ b/libs/zlib/CMakeLists.txt
@@ -18,6 +18,10 @@ set_target_properties(zlib.ndll
 	SUFFIX .ndll
 )
 
+if (UNIX AND NOT APPLE)
+	target_link_options(zlib.ndll PRIVATE "-Wl,--no-undefined")
+endif()
+
 install (
 	TARGETS zlib.ndll
 	DESTINATION ${DEST_NDLL}


### PR DESCRIPTION
If a symbol is undefined, it may cause a load time error. We can catch this at link time instead by using --no-undefined. Some ndlls intentionally allow undefined symbols, so this is not applied universally.

This helps avoid broken builds such as: https://gitlab.archlinux.org/archlinux/packaging/packages/neko/-/work_items/1