### PR TITLE
[cmake] Update to mbedtls 3.6.7

### DIFF
--- a/libs/ssl/CMakeLists.txt
+++ b/libs/ssl/CMakeLists.txt
@@ -36,8 +36,8 @@ if (STATIC_MBEDTLS)
 	endif()
 	ExternalProject_Add(MbedTLS
 		${EP_CONFIGS}
-		URL https://github.com/Mbed-TLS/mbedtls/releases/download/v3.6.0/mbedtls-3.6.0.tar.bz2
-		URL_HASH SHA256=3ecf94fcfdaacafb757786a01b7538a61750ebd85c4b024f56ff8ba1490fcd38
+		URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-3.6.7/mbedtls-3.6.7.tar.bz2
+		URL_HASH SHA256=a7e8bcbec0e6f761b4af24f25677626b35f762f68eef79c08677a363212d11f6
 		CMAKE_ARGS ${MBEDTLS_CMAKE_ARGS}
 		PATCH_COMMAND ${CMAKE_COMMAND} -Dsource=${CMAKE_SOURCE_DIR} -DMbedTLS_source=${CMAKE_BINARY_DIR}/libs/src/MbedTLS -P ${CMAKE_SOURCE_DIR}/cmake/patch_mbedtls.cmake
 		INSTALL_COMMAND echo skip install


### PR DESCRIPTION
This solves mac static build errors:
```
/Users/runner/work/neko/neko/libs/src/MbedTLS/library/ssl_tls13_keys.c:44:5: error: initializer-string for character array is too long, array size is 8 but initializer has size 9 (including the null terminating character); did you mean to use the 'nonstring' attribute? [-Werror,-Wunterminated-string-initialization]
   44 |     MBEDTLS_SSL_TLS1_3_LABEL_LIST
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/runner/work/neko/neko/libs/src/MbedTLS/library/ssl_tls13_keys.h:14:40: note: expanded from macro 'MBEDTLS_SSL_TLS1_3_LABEL_LIST'
   14 |     MBEDTLS_SSL_TLS1_3_LABEL(finished, "finished") \
      |                                        ^~~~~~~~~~
```

Upstream issue: https://github.com/Mbed-TLS/mbedtls/issues/9944